### PR TITLE
Ensure deterministic event cache builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for auto-aliasing module classes in tinker sessions
 
+### Fixed
+
+- Ensure module event discovery runs during event cache builds (`event:cache`/`optimize`) even if events are already cached at process start, preventing missing module listeners on repeated cache builds. Runtime performance remains unchanged.
+
 ## [2.2.0] - 2024-04-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ should work as expected in most cases:
 - Blade components will be auto-discovered
 - Event listeners will be auto-discovered
 
+Modular ensures module listeners are included when building Laravel's event cache (`event:cache`/`optimize`), even if an events cache exists when the process starts. Rebuilding the cache repeatedly will produce identical manifests. You can disable this behaviour via the `discover_events_during_cache_builds` config option.
+
 ### Commands
 
 #### Package Commands

--- a/config.php
+++ b/config.php
@@ -90,5 +90,19 @@ return [
 	| the presence of event discovery.
 	*/
 	
-	'should_discover_events' => null,
+       'should_discover_events' => null,
+
+       /*
+       |--------------------------------------------------------------------------
+       | Discover events during cache builds
+       |--------------------------------------------------------------------------
+       |
+       | When building Laravel's event cache (via `event:cache` or `optimize`),
+       | Modular will normally re-run event discovery even if an events cache
+       | already exists to ensure deterministic cache files. You can disable this
+       | behavior here to restore the legacy behaviour.
+       |
+       */
+
+       'discover_events_during_cache_builds' => true,
 ];

--- a/src/Support/ModularEventServiceProvider.php
+++ b/src/Support/ModularEventServiceProvider.php
@@ -31,16 +31,46 @@ class ModularEventServiceProvider extends ServiceProvider
 		});
 	}
 	
-	public function getEvents(): array
-	{
-		// If events are cached, or Modular event discovery is disabled, then we'll
-		// just let the normal event service provider handle all the event loading.
-		if ($this->app->eventsAreCached() || ! $this->shouldDiscoverEvents()) {
-			return [];
-		}
-		
-		return $this->discoverEvents();
-	}
+       public function getEvents(): array
+       {
+               // If events are cached we'll skip discovery unless we're currently building
+               // the events cache. The cache-building commands need to re-run discovery so
+               // that repeated cache builds produce identical manifests.
+               $discover_during_cache = config('app-modules.discover_events_during_cache_builds', true);
+
+               if (
+                       $this->app->eventsAreCached()
+                       && (! $discover_during_cache || ! $this->isCacheBuildProcess())
+               ) {
+                       return [];
+               }
+
+               // If event discovery has been disabled, let the normal service provider handle
+               // the event loading.
+               if (! $this->shouldDiscoverEvents()) {
+                       return [];
+               }
+
+               return $this->discoverEvents();
+       }
+
+       /**
+        * Determine if the current process is actively building Laravel's caches.
+        *
+        * We conservatively check the CLI arguments for "event:cache" or
+        * "optimize" to avoid relying on environment variables or other state.
+        */
+        protected function isCacheBuildProcess(): bool
+        {
+               if (PHP_SAPI !== 'cli') {
+                       return false;
+               }
+
+               $argv = $_SERVER['argv'] ?? [];
+
+               return in_array('event:cache', $argv, true)
+                       || in_array('optimize', $argv, true);
+        }
 	
 	public function shouldDiscoverEvents(): bool
 	{

--- a/tests/EventDiscovery/EventCacheBuildTest.php
+++ b/tests/EventDiscovery/EventCacheBuildTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace InterNACHI\Modular\Tests\EventDiscovery;
+
+use InterNACHI\Modular\Support\Facades\Modules;
+use InterNACHI\Modular\Tests\Concerns\PreloadsAppModules;
+use InterNACHI\Modular\Tests\TestCase;
+
+class EventCacheBuildTest extends TestCase
+{
+    use PreloadsAppModules;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('app-modules.should_discover_events', true);
+    }
+
+    public function test_event_cache_builds_are_deterministic(): void
+    {
+        $this->artisan('optimize:clear');
+
+        $event = 'Modules\\TestModule\\Events\\TestEvent';
+        $listener = 'Modules\\TestModule\\Listeners\\TestEventListener@handle';
+
+        $originalArgv = $_SERVER['argv'] ?? [];
+
+        try {
+            $_SERVER['argv'] = ['artisan', 'event:cache'];
+
+            $this->refreshApplication();
+            Modules::reload();
+            $this->artisan('event:cache');
+            $cache1 = require $this->app->getCachedEventsPath();
+            $this->assertTrue($this->cacheHasListener($cache1, $event, $listener));
+
+            $this->refreshApplication();
+            Modules::reload();
+            $this->artisan('event:cache');
+            $cache2 = require $this->app->getCachedEventsPath();
+            $this->assertTrue($this->cacheHasListener($cache2, $event, $listener));
+
+            $this->assertEquals($cache1, $cache2);
+        } finally {
+            $_SERVER['argv'] = $originalArgv;
+            $this->artisan('event:clear');
+        }
+    }
+
+    private function cacheHasListener(array $cache, string $event, string $listener): bool
+    {
+        foreach ($cache as $events) {
+            if (isset($events[$event]) && in_array($listener, $events[$event], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+class EventCacheBuildDisabledTest extends TestCase
+{
+    use PreloadsAppModules;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('app-modules.should_discover_events', true);
+        $app['config']->set('app-modules.discover_events_during_cache_builds', false);
+    }
+
+    public function test_event_cache_build_can_shrink_when_disabled(): void
+    {
+        $this->artisan('optimize:clear');
+
+        $event = 'Modules\\TestModule\\Events\\TestEvent';
+        $listener = 'Modules\\TestModule\\Listeners\\TestEventListener@handle';
+
+        $originalArgv = $_SERVER['argv'] ?? [];
+
+        try {
+            $_SERVER['argv'] = ['artisan', 'event:cache'];
+
+            $this->refreshApplication();
+            Modules::reload();
+            $this->artisan('event:cache');
+            $cache1 = require $this->app->getCachedEventsPath();
+            $this->assertTrue($this->cacheHasListener($cache1, $event, $listener));
+
+            $this->refreshApplication();
+            Modules::reload();
+            $this->artisan('event:cache');
+            $cache2 = require $this->app->getCachedEventsPath();
+            $this->assertFalse($this->cacheHasListener($cache2, $event, $listener));
+        } finally {
+            $_SERVER['argv'] = $originalArgv;
+            $this->artisan('event:clear');
+        }
+    }
+
+    private function cacheHasListener(array $cache, string $event, string $listener): bool
+    {
+        foreach ($cache as $events) {
+            if (isset($events[$event]) && in_array($listener, $events[$event], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- avoid skipping module event discovery during `event:cache`/`optimize` so repeated cache builds include the same listeners
- allow disabling this behavior via `discover_events_during_cache_builds` config
- document cache-build behavior and add coverage for default and disabled cases

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `composer check-style` *(fails: vendor/bin/php-cs-fixer: not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b033ed86ac8324869fabc039d58358